### PR TITLE
Security/form validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "guzzlehttp/guzzle": "^6.3",
-        "doctrine/doctrine-fixtures-bundle": "2.3.0"
+        "doctrine/doctrine-fixtures-bundle": "2.3.0",
+        "symfony/validator": "2.8.52"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a003d310d24dae7ec6511c03d0da5c03",
+    "content-hash": "8d52120b332d371544eef161b3f8ae4f",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/src/AppBundle/Entity/Award.php
+++ b/src/AppBundle/Entity/Award.php
@@ -40,6 +40,11 @@ class Award {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $award;
@@ -50,12 +55,22 @@ class Award {
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, nullable=true)
    */
   protected $award_funder;
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $award_url;

--- a/src/AppBundle/Entity/DataCollectionInstrument.php
+++ b/src/AppBundle/Entity/DataCollectionInstrument.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -48,16 +49,31 @@ class DataCollectionInstrument {
   protected $data_collection_instrument_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=256, nullable=true)
    */
   protected $url;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Notes cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=1026, nullable=true)
    */
   protected $notes;

--- a/src/AppBundle/Entity/DataLocation.php
+++ b/src/AppBundle/Entity/DataLocation.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 
 
 /**
@@ -36,16 +37,31 @@ class DataLocation {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Data location title cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $data_location;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Dataset location content cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028,nullable=true)
    */
   protected $location_content;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Enter a valid URL without html or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $data_access_url;
@@ -92,7 +108,7 @@ class DataLocation {
      */
     public function setDataAccessUrl($dataAccessUrl)
     {
-        $this->data_access_url = $dataAccessUrl;
+        $this->data_access_url = strip_tags($dataAccessUrl);
 
         return $this;
     }
@@ -161,7 +177,7 @@ class DataLocation {
      */
     public function setDataLocation($dataLocation)
     {
-        $this->data_location = $dataLocation;
+        $this->data_location = strip_tags($dataLocation);
 
         return $this;
     }
@@ -184,7 +200,7 @@ class DataLocation {
      */
     public function setLocationContent($locationContent)
     {
-        $this->location_content = $locationContent;
+        $this->location_content = strip_tags($locationContent);
 
         return $this;
     }

--- a/src/AppBundle/Entity/Dataset.php
+++ b/src/AppBundle/Entity/Dataset.php
@@ -47,6 +47,11 @@ class Dataset implements JsonSerializable {
 
   /**
    * @Assert\NotBlank()
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Title cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=255, unique=true)
    */
   protected $title;
@@ -64,6 +69,11 @@ class Dataset implements JsonSerializable {
 
   /**
    * @Assert\NotBlank()
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Description cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=3000)
    */
   protected $description;
@@ -94,12 +104,22 @@ class Dataset implements JsonSerializable {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Access instructions cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=3000, nullable=true)
    */
   protected $access_instructions;
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Licensing details cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=3000, nullable=true)
    */
   protected $licensing_details;
@@ -167,6 +187,11 @@ class Dataset implements JsonSerializable {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="This field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string", length=3000, nullable=true)
    */
   protected $data_location_description;

--- a/src/AppBundle/Entity/DatasetAlternateTitle.php
+++ b/src/AppBundle/Entity/DatasetAlternateTitle.php
@@ -75,7 +75,7 @@ class DatasetAlternateTitle {
      */
     public function setAltTitle($altTitle)
     {
-        $this->alt_title = $altTitle;
+        $this->alt_title = strip_tags($altTitle);
 
         return $this;
     }

--- a/src/AppBundle/Entity/DatasetFormat.php
+++ b/src/AppBundle/Entity/DatasetFormat.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class DatasetFormat {
 
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Format cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $format;

--- a/src/AppBundle/Entity/OtherResource.php
+++ b/src/AppBundle/Entity/OtherResource.php
@@ -108,7 +108,7 @@ class OtherResource {
      */
     public function setResourceName($resourceName)
     {
-        $this->resource_name = $resourceName;
+        $this->resource_name = strip_tags($resourceName);
 
         return $this;
     }
@@ -131,7 +131,7 @@ class OtherResource {
      */
     public function setResourceDescription($resourceDescription)
     {
-        $this->resource_description = $resourceDescription;
+        $this->resource_description = strip_tags($resourceDescription);
 
         return $this;
     }
@@ -154,7 +154,7 @@ class OtherResource {
      */
     public function setResourceUrl($resourceUrl)
     {
-        $this->resource_url = $resourceUrl;
+        $this->resource_url = strip_tags($resourceUrl);
 
         return $this;
     }

--- a/src/AppBundle/Entity/Person.php
+++ b/src/AppBundle/Entity/Person.php
@@ -133,7 +133,7 @@ class Person {
      */
     public function setFullName($fullName)
     {
-        $this->full_name = $fullName;
+        $this->full_name = strip_tags($fullName);
 
         return $this;
     }
@@ -156,7 +156,7 @@ class Person {
      */
     public function setLastName($lastName)
     {
-        $this->last_name = $lastName;
+        $this->last_name = strip_tags($lastName);
 
         return $this;
     }
@@ -179,7 +179,7 @@ class Person {
      */
     public function setFirstName($firstName)
     {
-        $this->first_name = $firstName;
+        $this->first_name = strip_tags($firstName);
 
         return $this;
     }
@@ -225,7 +225,7 @@ class Person {
      */
     public function setBioUrl($bioUrl)
     {
-        $this->bio_url = $bioUrl;
+        $this->bio_url = strip_tags($bioUrl);
 
         return $this;
     }
@@ -249,7 +249,7 @@ class Person {
      */
     public function setEmail($email)
     {
-        $this->email = $email;
+        $this->email = strip_tags($email);
 
         return $this;
     }

--- a/src/AppBundle/Entity/Publication.php
+++ b/src/AppBundle/Entity/Publication.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,16 +40,31 @@ class Publication {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Citation cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512)
    */
   protected $citation;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $url;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="DOI cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=128, nullable=true)
    */
   protected $doi;

--- a/src/AppBundle/Entity/Publisher.php
+++ b/src/AppBundle/Entity/Publisher.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class Publisher {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $publisher_name;
@@ -49,6 +55,11 @@ class Publisher {
   protected $slug;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, nullable=true)
    */
   protected $publisher_url;

--- a/src/AppBundle/Entity/PublisherCategory.php
+++ b/src/AppBundle/Entity/PublisherCategory.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -37,6 +38,11 @@ class PublisherCategory {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Category cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256)
    */
   protected $publisher_category;

--- a/src/AppBundle/Entity/RelatedEquipment.php
+++ b/src/AppBundle/Entity/RelatedEquipment.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,16 +40,31 @@ class RelatedEquipment {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $related_equipment;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Description cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, unique=false, nullable=true)
    */
   protected $equipment_description;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=1028, unique=false, nullable=true)
    */
   protected $equipment_url;

--- a/src/AppBundle/Entity/RelatedSoftware.php
+++ b/src/AppBundle/Entity/RelatedSoftware.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,16 +40,31 @@ class RelatedSoftware {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=128, unique=true)
    */
   protected $software_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Description cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, unique=false, nullable=true)
    */
   protected $software_description;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="URL field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=512, unique=false, nullable=true)
    */
   protected $software_url;

--- a/src/AppBundle/Entity/SubjectDomain.php
+++ b/src/AppBundle/Entity/SubjectDomain.php
@@ -90,7 +90,7 @@ class SubjectDomain {
      */
     public function setSubjectDomain($subjectDomain)
     {
-        $this->subject_domain = $subjectDomain;
+        $this->subject_domain = strip_tags($subjectDomain);
 
         return $this;
     }
@@ -113,7 +113,7 @@ class SubjectDomain {
      */
     public function setMeshCode($meshCode)
     {
-        $this->mesh_code = $meshCode;
+        $this->mesh_code = strip_tags($meshCode);
 
         return $this;
     }

--- a/src/AppBundle/Entity/SubjectGeographicArea.php
+++ b/src/AppBundle/Entity/SubjectGeographicArea.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectGeographicArea {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $geographic_area_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Authority cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256, nullable=true)
    */
   protected $geographic_area_authority;

--- a/src/AppBundle/Entity/SubjectGeographicAreaDetail.php
+++ b/src/AppBundle/Entity/SubjectGeographicAreaDetail.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectGeographicAreaDetail {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Name cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $geographic_area_detail_name;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Authority cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=256, nullable=true)
    */
   protected $geographic_area_detail_authority;

--- a/src/AppBundle/Entity/SubjectKeyword.php
+++ b/src/AppBundle/Entity/SubjectKeyword.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,6 +40,11 @@ class SubjectKeyword {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Keywords cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $keyword;

--- a/src/AppBundle/Entity/SubjectOfStudy.php
+++ b/src/AppBundle/Entity/SubjectOfStudy.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -39,11 +40,21 @@ class SubjectOfStudy {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $subject_of_study;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, nullable=true)
    */
   protected $species;

--- a/src/AppBundle/Entity/SubjectPopulationAge.php
+++ b/src/AppBundle/Entity/SubjectPopulationAge.php
@@ -2,6 +2,7 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 
 
@@ -38,6 +39,11 @@ class SubjectPopulationAge {
   protected $id;
 
   /**
+   * @Assert\Regex(
+   *     pattern="/<[a-z][\s\S]*>/i",
+   *     match=false,
+   *     message="Field cannot contain HTML or script tags"
+   * )
    * @ORM\Column(type="string",length=255, unique=true)
    */
   protected $age_group;


### PR DESCRIPTION
Hey @dellurea,

This PR adds the symfony validator and some dependencies to handle input validation on the forms.  We can do more with enforcing input, but this was to make sure that script can't be added to our database to satisfy our security requirements.

To verify - <script> or any valid html/xml tags should not be able to be entered for our fields.  There are a few fields where the data is sanitized of these tags instead of blocking submission, due to how those separate form fields are rendered (i.e. Data Location, Other Resource, Person, etc).  You can tell the difference between these fields because I used php's built-in strip_tags helper method on the relevant entities.

