### PR TITLE
Feature/set default boolean and

### DIFF
--- a/src/AppBundle/Service/SolrSearchr.php
+++ b/src/AppBundle/Service/SolrSearchr.php
@@ -168,7 +168,9 @@ class SolrSearchr {
           $quoted_keyword_query_string = $keyword_query_string;
         }
         // search all fields, and then search the title field separately to improve relevancy
-        $final_query_string = $keyword_query_string ;
+        // $final_query_string = $keyword_query_string . " OR dataset_title:" . $quoted_keyword_query_string;
+        // MSK is removing the additional OR for the title search as it breaks default AND searching
+        $final_query_string = $keyword_query_string;
       } else {
         // if we're limiting to one field i.e., we've clicked on a certain "Subject Domain" from a dataset record
         // Solr requires you to use double quotes around the search terms when searching a specific field

--- a/src/AppBundle/Service/SolrSearchr.php
+++ b/src/AppBundle/Service/SolrSearchr.php
@@ -168,7 +168,7 @@ class SolrSearchr {
           $quoted_keyword_query_string = $keyword_query_string;
         }
         // search all fields, and then search the title field separately to improve relevancy
-        $final_query_string = $keyword_query_string . " OR dataset_title:" . $quoted_keyword_query_string;
+        $final_query_string = $keyword_query_string ;
       } else {
         // if we're limiting to one field i.e., we've clicked on a certain "Subject Domain" from a dataset record
         // Solr requires you to use double quotes around the search terms when searching a specific field


### PR DESCRIPTION
@dellurea This PR addresses one of the to-do items - making the default search AND instead of OR.  It turns out the reason Solr configuration wasn't working was because of a hard-coded OR in the application code.  I removed it, but also documented it in case we need to go back.

