### PR TITLE
Feature/remove internal dataset from view

### DIFF
--- a/app/Resources/views/default/results.html.twig
+++ b/app/Resources/views/default/results.html.twig
@@ -106,9 +106,6 @@
    {% for item in results.resultItems %}
     <li class="dataset-summary"> 
     <h4 class="dataset-title"><a class="dataset-title-link" href="{{ path("view_dataset", {"uid":item.id}) }}">{{ item.dataset_title }}</a>
-      {% if item.origin == "Internal" %}
-        <div class="internal-dataset-badge">{{ internal_dataset_text }}</div>
-      {% endif %}
     </h4>
             <dl class="dl-horizontal">
 
@@ -195,19 +192,6 @@
 <div class="col-sm-2 col-sm-pull-10" id="facets-pane">
 <h4 class="facet-pane-header">Filter by</h4>
 
-  <div class="checkbox facet-section" id="internal-only-filter-container">
-    <label>
-      <input 
-        class="" 
-        {% if "origin_fq:Internal" in currentSearch.facets %}
-          checked="checked"
-        {% endif %}
-        type="checkbox" 
-        id="internal-only-filter"
-      >
-        {{ institution_name_short }} Datasets Only 
-    </label>
-  </div>
   {% for category,facets in results.facets if category != 'Origin' %}
     {% set facetSection = [] %}
     {% for facet in facets %} 

--- a/src/AppBundle/Controller/GeneralController.php
+++ b/src/AppBundle/Controller/GeneralController.php
@@ -230,32 +230,17 @@ class GeneralController extends Controller
 		
 		}
 
-		if ($dataset->getOrigin() == 'Internal') {
-      if ($this->get('templating')->exists('institution/view_dataset_internal.html.twig')) {
-        return $this->render('institution/view_dataset_internal.html.twig', array(
-          'dataset' => $dataset,
-        )); 
-      }
-      else {
-        return $this->render('default/view_dataset_internal.html.twig', array(
-          'dataset' => $dataset,
-        ));
-      }
 
-		} else {
-        if ($this->get('templating')->exists('institution/view_dataset_external.html.twig')) {
-          return $this->render('institution/view_dataset_external.html.twig', array(
-            'dataset' => $dataset,
-          ));
-        }
-        else {
-          return $this->render('default/view_dataset_external.html.twig', array(
-            'dataset' => $dataset,
-          ));
-        }
-		}
-  }
-  
+    if ($this->get('templating')->exists('institution/view_dataset_external.html.twig')) {
+      return $this->render('institution/view_dataset_external.html.twig', array(
+        'dataset' => $dataset,
+      ));
+    }
+    else {
+      return $this->render('default/view_dataset_external.html.twig', array(
+        'dataset' => $dataset,
+      ));
+    }
 	
-		
+  }	
 }


### PR DESCRIPTION
@dellurea This PR addresses the request to remove the internal dataset display and filter from the UI.

- Removes the MSK Datasets Only checkbox
- Removes the Internal Datasets Badge from Search Results
- Internal Dataset View is no longer rendered from the controller based on the dataset origin.