### PR TITLE
Feature/oncotree api metadata

### DIFF
--- a/app/Resources/views/institution/view_dataset_external.html.twig
+++ b/app/Resources/views/institution/view_dataset_external.html.twig
@@ -255,6 +255,7 @@ $(function () {
         <dt>OncoTree Cancer Tag(s)</dt>
          <dd>{% for keyword in dataset.subjectKeywords %}
           <div class="multiple-item-list"><a href="/search?keyword=subject_keywords:{{ keyword.getDisplayName }}">{{ keyword.getDisplayName }}</a></div>
+          <div class="api-test"{{ keyword.getOncoTreeMetadata }}</div>
           {% endfor %}
           </dd>
         {% endif %}

--- a/app/Resources/views/institution/view_dataset_external.html.twig
+++ b/app/Resources/views/institution/view_dataset_external.html.twig
@@ -255,7 +255,7 @@ $(function () {
         <dt>OncoTree Cancer Tag(s)</dt>
          <dd>{% for keyword in dataset.subjectKeywords %}
           <div class="multiple-item-list"><a href="/search?keyword=subject_keywords:{{ keyword.getDisplayName }}">{{ keyword.getDisplayName }}</a></div>
-          <div class="api-test"{{ keyword.getOncoTreeMetadata }}</div>
+          <div class="api-test">{{ keyword.getOncoTreeMetadata }}</div>
           {% endfor %}
           </dd>
         {% endif %}

--- a/app/Resources/views/institution/view_dataset_external.html.twig
+++ b/app/Resources/views/institution/view_dataset_external.html.twig
@@ -54,6 +54,27 @@ $(function () {
         }
     }, 200);
   });
+
+    // initialize OncoTree popovers
+  $('.oncotree-list [data-toggle="popover"]').popover({
+     'html':'true',
+     'animation':false,
+     'trigger':'manual',
+     'placement':'bottom',
+  }).on("mouseenter", function () {
+    var _this = this;
+    $(this).popover("show");
+    $(".popover").on("mouseleave", function () {
+      $(_this).popover('hide');
+    });
+  }).on("mouseleave", function () {
+    var _this = this;
+    setTimeout(function () {
+        if (!$(".popover:hover").length) {
+            $(_this).popover("hide");
+        }
+    }, 200);
+  });
 })
 </script>
 {% endblock %}
@@ -253,11 +274,19 @@ $(function () {
 
      {% if (dataset.subjectKeywords.count > 0) %}
         <dt>OncoTree Cancer Tag(s)</dt>
-         <dd>{% for keyword in dataset.subjectKeywords %}
-          <div class="multiple-item-list"><a href="/search?keyword=subject_keywords:{{ keyword.getDisplayName }}">{{ keyword.getDisplayName }}</a></div>
-          <div class="api-test">{{ keyword.getOncoTreeMetadata }}</div>
+         <dd><span class="oncotree-list">{% for keyword in dataset.subjectKeywords %}
+          {% if (keyword.getOncoTreeMetadata is not empty) %}
+          {% set popoverContent = '' %}
+          {% set popoverContent = keyword.getOncoTreeMetadata %}
+            {% if popoverContent %}
+              <a tabindex="0" class="oncotree-link" href="/search?keyword=subject_keywords:{{ keyword.getDisplayName }}" role="button" data-toggle="popover" data-original-title="{{ keyword.getDisplayName }}" data-content="{{ popoverContent }}">{{ keyword.getDisplayName }}</a><br />
+            {% endif %}
+          {% else %}
+            <a tabindex="0" class="oncotree-link" href="/search?keyword=subject_keywords:{{ keyword.getDisplayName }}" title="{{ keyword.getDisplayName }}">{{ keyword.getDisplayName }}</a><br />
+          {% endif %}
+          
           {% endfor %}
-          </dd>
+          </span></dd>
         {% endif %}
      
      </dl>

--- a/src/AppBundle/Entity/SubjectKeyword.php
+++ b/src/AppBundle/Entity/SubjectKeyword.php
@@ -151,6 +151,7 @@ class SubjectKeyword {
             $returnhtml .= "<p><strong>Main Type:</strong> {$onco_data[0]->mainType}</p>";
             $returnhtml .= "<p><strong>Tissue:</strong> {$onco_data[0]->tissue}</p>";
             $returnhtml .= "<p><strong>Parent:</strong> {$onco_data[0]->parent}</p>";
+            $returnhtml .= "<p><a href='http://oncotree.mskcc.org' target='_blank'>More at OncoTree</a></p>";
             return $returnhtml;
     
         }

--- a/src/AppBundle/Entity/SubjectKeyword.php
+++ b/src/AppBundle/Entity/SubjectKeyword.php
@@ -75,6 +75,7 @@ class SubjectKeyword {
     return $this->keyword;
   }
 
+
     /**
      * Get id
      *
@@ -129,6 +130,36 @@ class SubjectKeyword {
     public function getMeshCode()
     {
         return $this->mesh_code;
+    }
+
+
+    /**
+     * get OncoTree Metadata
+     *
+     * @return string
+     */
+    public function getOncoTreeMetadata() {
+        $ocode = $this->keyword;
+        $api_url = "http://oncotree.mskcc.org/api/tumorTypes/search/code/{$ocode}";
+        // Read JSON file
+        $json_data = file_get_contents($api_url);
+        if ($json_data === false) {
+            echo "Invalid OncoTree Code";   
+        } else {
+            $onco_data = json_decode($json_data);
+                //print_r($onco_data); //This works
+                
+                echo "Code: ".$onco_data[0]->code;
+                echo "<br />";
+                echo "Name: ".$onco_data[0]->name;
+                echo "<br />";
+                echo "Main Type: ".$onco_data[0]->mainType;
+                echo "<br />";
+                echo "Tissue: ".$onco_data[0]->tissue;
+                echo "<br />";
+                echo "Parent: ".$onco_data[0]->parent;
+                
+        }
     }
 
 

--- a/src/AppBundle/Entity/SubjectKeyword.php
+++ b/src/AppBundle/Entity/SubjectKeyword.php
@@ -147,18 +147,12 @@ class SubjectKeyword {
         } else {
             $json_data = @file_get_contents($api_url);
             $onco_data = json_decode($json_data);
-                //print_r($onco_data); //This works
-                
-                echo "Code: ".$onco_data[0]->code;
-                echo "<br />";
-                echo "Name: ".$onco_data[0]->name;
-                echo "<br />";
-                echo "Main Type: ".$onco_data[0]->mainType;
-                echo "<br />";
-                echo "Tissue: ".$onco_data[0]->tissue;
-                echo "<br />";
-                echo "Parent: ".$onco_data[0]->parent;
-                
+            $returnhtml =  "<p><strong>Name:</strong> {$onco_data[0]->name}</p>";
+            $returnhtml .= "<p><strong>Main Type:</strong> {$onco_data[0]->mainType}</p>";
+            $returnhtml .= "<p><strong>Tissue:</strong> {$onco_data[0]->tissue}</p>";
+            $returnhtml .= "<p><strong>Parent:</strong> {$onco_data[0]->parent}</p>";
+            return $returnhtml;
+    
         }
     }
 

--- a/src/AppBundle/Entity/SubjectKeyword.php
+++ b/src/AppBundle/Entity/SubjectKeyword.php
@@ -142,10 +142,10 @@ class SubjectKeyword {
         $ocode = $this->keyword;
         $api_url = "http://oncotree.mskcc.org/api/tumorTypes/search/code/{$ocode}";
         // Read JSON file
-        $json_data = file_get_contents($api_url);
-        if ($json_data === false) {
-            echo "Invalid OncoTree Code";   
+        if (@file_get_contents($api_url) === false) {
+            return;   
         } else {
+            $json_data = @file_get_contents($api_url);
             $onco_data = json_decode($json_data);
                 //print_r($onco_data); //This works
                 


### PR DESCRIPTION
@dellurea 

This PR adds the OncoTree API integration for the OncoTree tags that you requested.  The additional metadata will display if the code exists in the API as a popover.  I have some codes that don't exist in the API in my dev environment and they are clickable as filters but do not have popovers.  

![image](https://user-images.githubusercontent.com/4126936/77777519-144ed400-7026-11ea-8c61-4192c22b31d2.png)
