### PR TITLE
Fix delete and archive dataset actions

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -188,6 +188,9 @@
           <a href="{{ path('admin_users') }}">Manage Website Users</a>
          </li>
          <div class="spacer25"></div>
+          <li class="{% if 'update/Dataset' in app.request.requestUri  %}active{% endif %}" role="presentation">
+            <a href="{{ path('update_entity', {entityName:'ArchivedDatasets'}) }}">View Archived Datasets</a>
+         </li>
          <li class="{% if 'remove/Dataset' in app.request.requestUri %}active{% endif %}" role="presentation">
           <a href="{{ path('remove_entity', {'entityName':'Dataset'}) }}">Remove a Dataset</a>
          </li>

--- a/app/Resources/views/default/remove_success.html.twig
+++ b/app/Resources/views/default/remove_success.html.twig
@@ -23,6 +23,9 @@ The {{ entityName }} was removed successfully.
 <p>
 <a href="{{ path('admin_manage') }}">click here</a> to manage other entities.
 </p>
+<p>
+    <a href="{{ path('update_entity', {entityName:'ArchivedDatasets'}) }}">View archived datasets</a>
+</p>
 
 
 </div>

--- a/app/Resources/views/default/remove_success.html.twig
+++ b/app/Resources/views/default/remove_success.html.twig
@@ -23,9 +23,6 @@ The {{ entityName }} was removed successfully.
 <p>
 <a href="{{ path('admin_manage') }}">click here</a> to manage other entities.
 </p>
-<p>
-    <a href="{{ path('update_entity', {entityName:'ArchivedDatasets'}) }}">View archived datasets</a>
-</p>
 
 
 </div>

--- a/app/Resources/views/institution/list_of_entities_to_update.html.twig
+++ b/app/Resources/views/institution/list_of_entities_to_update.html.twig
@@ -1,0 +1,52 @@
+{% extends 'base.html.twig' %}
+
+{% block page_title %}
+ <title>Update Entities</title>
+{% endblock %}
+
+{% block content %}
+
+<div class="col-xs-7">
+  <div class="page-header entities-list">
+    <h1>View/Update {{ displayName }}</h1>
+    <p>
+    {% if displayName != 'Archived Dataset' %}
+      <span class="add-new-entity-link">
+        or <a href="{{ path('add_new_entity', {'entityName':entityName}) }}">add a new {{ displayName }}</a>
+      </span>
+    {% endif %}
+    {% if entityName == 'Dataset' and displayName != 'Archived Dataset' %}
+      <span class="view-archived-datasets-link">
+        <a href="{{ path('update_entity', {entityName:'ArchivedDatasets'}) }}">View archived datasets</a>
+      </span>
+    {% endif %}
+    </p>
+  </div>
+
+<ul>
+ 
+{% for entity in entities %}
+  {% if displayName == 'Archived Dataset' %}
+      <li class="entities-list-item">
+        <a href="{{ path('update_entity', {'entityName':entityName,'slug':entity.slug}) }}">{{ entity.getDisplayName }}</a>
+      </li>
+  {% elseif displayName == 'Dataset' and entity.getArchived|default(false) != true %}
+      <li class="entities-list-item">
+        <a href="{{ path('update_dataset', {'uid':entity.datasetUid}) }}">{{ entity.getDisplayName }}</a>
+      </li>
+  {% else %}
+    {% if entity.getArchived|default(false) != true %}
+      <li class="entities-list-item">
+        <a href="{{ path('update_entity', {'entityName':entityName,'slug':entity.slug}) }}">{{ entity.getDisplayName }}</a>
+      </li>
+    {% endif %}
+  {% endif %}
+{% endfor %}
+ 
+</ul>
+
+<div class="spacer25"></div>
+
+</div>
+
+{% endblock %}

--- a/app/Resources/views/institution/list_of_entities_to_update.html.twig
+++ b/app/Resources/views/institution/list_of_entities_to_update.html.twig
@@ -29,6 +29,7 @@
   {% if displayName == 'Archived Dataset' %}
       <li class="entities-list-item">
         <a href="{{ path('update_dataset', {'uid':entity.datasetUid}) }}">{{ entity.getDisplayName }}</a>
+        <a class="btn btn-danger" href="/remove/Dataset/{{ entity.getDatasetUid }}">Delete</a>
       </li>
   {% elseif displayName == 'Dataset' and entity.getArchived|default(false) != true %}
       <li class="entities-list-item">
@@ -37,7 +38,7 @@
   {% else %}
     {% if entity.getArchived|default(false) != true %}
       <li class="entities-list-item">
-        <a href="{{ path('update_dataset', {'uid':entity.datasetUid}) }}">{{ entity.getDisplayName }}</a>
+        <a href="{{ path('update_entity', {'entityName':entityName,'slug':entity.slug}) }}">{{ entity.getDisplayName }}</a>
       </li>
     {% endif %}
   {% endif %}

--- a/app/Resources/views/institution/list_of_entities_to_update.html.twig
+++ b/app/Resources/views/institution/list_of_entities_to_update.html.twig
@@ -28,7 +28,7 @@
 {% for entity in entities %}
   {% if displayName == 'Archived Dataset' %}
       <li class="entities-list-item">
-        <a href="{{ path('update_entity', {'entityName':entityName,'slug':entity.slug}) }}">{{ entity.getDisplayName }}</a>
+        <a href="{{ path('update_dataset', {'uid':entity.datasetUid}) }}">{{ entity.getDisplayName }}</a>
       </li>
   {% elseif displayName == 'Dataset' and entity.getArchived|default(false) != true %}
       <li class="entities-list-item">
@@ -37,7 +37,7 @@
   {% else %}
     {% if entity.getArchived|default(false) != true %}
       <li class="entities-list-item">
-        <a href="{{ path('update_entity', {'entityName':entityName,'slug':entity.slug}) }}">{{ entity.getDisplayName }}</a>
+        <a href="{{ path('update_dataset', {'uid':entity.datasetUid}) }}">{{ entity.getDisplayName }}</a>
       </li>
     {% endif %}
   {% endif %}

--- a/src/AppBundle/Controller/UpdateController.php
+++ b/src/AppBundle/Controller/UpdateController.php
@@ -52,13 +52,24 @@ class UpdateController extends Controller {
     $userIsAdmin = $this->get('security.context')->isGranted('ROLE_ADMIN');
     if ($uid == null) {
       $allEntities = $em->getRepository('AppBundle\Entity\Dataset')->findBy([], ['slug'=>'ASC']);
-      return $this->render('default/list_of_entities_to_update.html.twig', array(
-        'entities'    => $allEntities,
-        'entityName'  => 'Dataset',
-        'adminPage'   => true,
-        'userIsAdmin' => $userIsAdmin,
-        'displayName' => 'Dataset'
-      ));
+      if ($this->get('templating')->exists('institution/list_of_entities_to_update.html.twig')) {
+        return $this->render('institution/list_of_entities_to_update.html.twig', array(
+          'entities'    => $allEntities,
+          'entityName'  => 'Dataset',
+          'adminPage'   => true,
+          'userIsAdmin' => $userIsAdmin,
+          'displayName' => 'Dataset'
+        ));
+      }
+      else {
+        return $this->render('default/list_of_entities_to_update.html.twig', array(
+          'entities'    => $allEntities,
+          'entityName'  => 'Dataset',
+          'adminPage'   => true,
+          'userIsAdmin' => $userIsAdmin,
+          'displayName' => 'Dataset'
+        ));
+      }
     }
     $thisEntity = $em->getRepository('AppBundle\Entity\Dataset')->findOneBy(array('dataset_uid'=>$uid));
     if (!$thisEntity) {
@@ -128,13 +139,24 @@ class UpdateController extends Controller {
     $userIsAdmin = $this->get('security.context')->isGranted('ROLE_ADMIN');
     if ($user == null) {
       $allEntities = $em->getRepository('AppBundle\Entity\Security\User')->findBy([], ['slug'=>'ASC']);
-      return $this->render('default/list_of_entities_to_update.html.twig', array(
-        'entities'   => $allEntities,
-        'entityName' => 'User',
-        'adminPage'  => true,
-        'userIsAdmin'=>$userIsAdmin,
-        'displayName'=>'User',
-      ));
+      if ($this->get('templating')->exists('institution/list_of_entities_to_update.html.twig')) {
+        return $this->render('institution/list_of_entities_to_update.html.twig', array(
+          'entities'   => $allEntities,
+          'entityName' => 'User',
+          'adminPage'  => true,
+          'userIsAdmin'=>$userIsAdmin,
+          'displayName'=>'User',
+        ));
+      }
+      else {
+        return $this->render('default/list_of_entities_to_update.html.twig', array(
+          'entities'   => $allEntities,
+          'entityName' => 'User',
+          'adminPage'  => true,
+          'userIsAdmin'=>$userIsAdmin,
+          'displayName'=>'User',
+        ));
+      }
     }
     $thisEntity = $em->getRepository('AppBundle\Entity\Security\User')->findOneBySlug($user);
     if (!$thisEntity) {
@@ -205,13 +227,24 @@ class UpdateController extends Controller {
       } else {
         $allEntities = $em->getRepository($updateEntity)->findBy([], ['slug'=>'ASC']);
       }
-      return $this->render('default/list_of_entities_to_update.html.twig', array(
-        'entities'    => $allEntities,
-        'entityName'  => $entityName,
-        'adminPage'   => true,
-        'userIsAdmin' => $userIsAdmin,
-        'displayName' => $entityTypeDisplayName
-      ));
+      if ($this->get('templating')->exists('institution/list_of_entities_to_update.html.twig')) {
+        return $this->render('institution/list_of_entities_to_update.html.twig', array(
+          'entities'    => $allEntities,
+          'entityName'  => $entityName,
+          'adminPage'   => true,
+          'userIsAdmin' => $userIsAdmin,
+          'displayName' => $entityTypeDisplayName
+        ));
+      }
+      else {
+        return $this->render('default/list_of_entities_to_update.html.twig', array(
+          'entities'    => $allEntities,
+          'entityName'  => $entityName,
+          'adminPage'   => true,
+          'userIsAdmin' => $userIsAdmin,
+          'displayName' => $entityTypeDisplayName
+        ));
+      }
     }
 
     $thisEntity = $em->getRepository($updateEntity)->findOneBySlug($slug);

--- a/src/AppBundle/Entity/Dataset.php
+++ b/src/AppBundle/Entity/Dataset.php
@@ -470,6 +470,11 @@ class Dataset implements JsonSerializable {
    **/
   protected $data_locations;
 
+  /**
+   * @ORM\OneToMany(targetEntity="DataLocationURL", mappedBy="datasets_dataset_uid", cascade={"all"})
+   **/
+  protected $data_location_urls;
+
 
   /**
    * @ORM\OneToMany(targetEntity="OtherResource", mappedBy="datasets_dataset_uid", cascade={"all"})

--- a/src/AppBundle/Entity/Dataset.php
+++ b/src/AppBundle/Entity/Dataset.php
@@ -109,11 +109,6 @@ class Dataset implements JsonSerializable {
 
 
   /**
-   * @Assert\Regex(
-   *     pattern="/<[a-z][\s\S]*>/i",
-   *     match=false,
-   *     message="Access instructions cannot contain HTML or script tags"
-   * )
    * @ORM\Column(type="string", length=3000, nullable=true)
    */
   protected $access_instructions;

--- a/src/AppBundle/Entity/Dataset.php
+++ b/src/AppBundle/Entity/Dataset.php
@@ -74,11 +74,6 @@ class Dataset implements JsonSerializable {
 
   /**
    * @Assert\NotBlank()
-   * @Assert\Regex(
-   *     pattern="/<[a-z][\s\S]*>/i",
-   *     match=false,
-   *     message="Description cannot contain HTML or script tags"
-   * )
    * @ORM\Column(type="string", length=3000)
    */
   protected $description;

--- a/src/AppBundle/Form/Type/DatasetAsAdminType.php
+++ b/src/AppBundle/Form/Type/DatasetAsAdminType.php
@@ -184,7 +184,7 @@ class DatasetAsAdminType extends AbstractType {
           },
           function ($submittedInstructions) {
             // remove most HTML tags (keep br,a,b,strong,ol,ul,li)
-            $cleaned = strip_tags($submittedInstructions, '<br><br/><a><b><strong><ol><ul><li>');
+            $cleaned = strip_tags($submittedInstructions, '<br><br/><a><b><strong><ol><ul><li><p>');
 
             // transform any \n to real <br/>
             return str_replace("\n", '<br/>', $cleaned);

--- a/src/AppBundle/Form/Type/DatasetAsAdminType.php
+++ b/src/AppBundle/Form/Type/DatasetAsAdminType.php
@@ -183,8 +183,8 @@ class DatasetAsAdminType extends AbstractType {
             return preg_replace('#<br\s*/?>#i', "\n", $originalInstructions);
           },
           function ($submittedInstructions) {
-            // remove most HTML tags (but not br,a,b,strong)
-            $cleaned = strip_tags($submittedInstructions, '<br><br/><a><b><strong>');
+            // remove most HTML tags (keep br,a,b,strong,ol,ul,li)
+            $cleaned = strip_tags($submittedInstructions, '<br><br/><a><b><strong><ol><ul><li>');
 
             // transform any \n to real <br/>
             return str_replace("\n", '<br/>', $cleaned);

--- a/src/AppBundle/Form/Type/DatasetAsAdminType.php
+++ b/src/AppBundle/Form/Type/DatasetAsAdminType.php
@@ -127,6 +127,23 @@ class DatasetAsAdminType extends AbstractType {
       'attr'=>array('rows'=>'7','placeholder'=>'Please provide a brief description of the dataset'),
       'label'    => 'Description'
     ));
+
+    //strip out most HTML tags, allow <a>, <b>, <strong>, <br>, <br />
+    $builder->get('description')
+    ->addModelTransformer(new CallbackTransformer(
+                      // transform <br/> to \n so the textarea reads easier
+        function ($originalDescription) {
+          return preg_replace('#<br\s*/?>#i', "\n", $originalDescription);
+        },
+        function ($submittedDescription) {
+          // remove most HTML tags (keep br,a,b,strong,ol,ul,li)
+          $cleaned = strip_tags($submittedDescription, '<br><br/><a><b><strong><ol><ul><li><p>');
+
+          // transform any \n to real <br/>
+          return str_replace("\n", '<br/>', $cleaned);
+        }
+    ));
+
     $builder->add('published', 'choice', array(
       'required' => false,
       'expanded' => true,


### PR DESCRIPTION
This PR addresses some bugs with the backend interface when working with datasets:

- Fixes bad links to archived datasets - archived datasets can now be edited and unarchived if desired
- Fixes unresolved foreign key constraint on data_location_urls that prevented deletion of a dataset
- Removes regex validation for Description and Access instruction text area fields in lieu of callback transformer
- Transform allows HTML in Description and Access Instruction metadata fields for specific tags only (a, br, p, ol, ul, li, strong)
- Adds the ability to delete an archived dataset and adds a delete button to the View Archived Datasets page